### PR TITLE
Ensure visibility modifiers on PHP classes

### DIFF
--- a/includes/finanzen.class.php
+++ b/includes/finanzen.class.php
@@ -384,7 +384,7 @@ class FinanzenNEW extends functions
      * 
      * @return string
      */
-    function getCategoryForUmsatz($id) 
+    public function getCategoryForUmsatz($id)
     {
         $list = [
         "amazon",
@@ -471,7 +471,7 @@ class FinanzenNEW extends functions
      * 
      * @return void
      */
-    function getBuchDesc(int $buchnr, int $kontoid, int $monat, int $jahr, string $view) 
+    public function getBuchDesc(int $buchnr, int $kontoid, int $monat, int $jahr, string $view)
     {
         
         echo "<div class='separateDivBox'>";

--- a/includes/learner.class.php
+++ b/includes/learner.class.php
@@ -34,7 +34,7 @@ class Learner extends Functions
      * 
      * @return void
      */
-    function newheader() 
+    public function newheader()
     {
         echo '<meta http-equiv="content-type" content="text/html; charset=utf-8" />';
         echo '<link rel="apple-touch-icon" sizes="57x57" href="/apple-icon-57x57.png">';
@@ -91,7 +91,7 @@ class Learner extends Functions
      * 
      * @return void
      */
-    function learnerWelcome() 
+    public function learnerWelcome()
     {
         echo "<div class='outerUebung'>";
 
@@ -189,7 +189,7 @@ class Learner extends Functions
      * 
      * @return void
      */
-    function getSprachen() 
+    public function getSprachen()
     {
         $getsprachen = $this->getObjektInfo("SELECT * FROM vokabeln_sprachauswahl");
         if (sizeof($getsprachen) == 1) {
@@ -214,14 +214,14 @@ class Learner extends Functions
         echo "</ul>";
     }
 
-    function learnfooter() 
+    public function learnfooter()
     {
         echo "<div class='footer'>"; 
             echo "<p><br>Version 2019-01-07 by Steven Schödel</p>"; 
         echo "</div>";
     }
 
-    function showLinks() 
+    public function showLinks()
     {
         echo "<ul class='finanzNAV'>";
 
@@ -260,7 +260,7 @@ class Learner extends Functions
         echo "</ul>";
     }
 
-    function showAllVokablen() 
+    public function showAllVokablen()
     {
         if (isset($_GET['showAll'])) {
             if (isset($_SESSION['vokabelkat'])) {
@@ -283,7 +283,7 @@ class Learner extends Functions
      * 
      * @return void
      */
-    function showStats()
+    public function showStats()
     {
         if (isset($_SESSION['vokabelkat'])) {
             echo "<div>";
@@ -379,7 +379,7 @@ class Learner extends Functions
      * 
      * @return void
      */
-    function setVokSchwierigkeit() 
+    public function setVokSchwierigkeit()
     {
         if (isset($_GET['good'])) {
             $_SESSION['vokLeicht'] = 1;
@@ -400,7 +400,7 @@ class Learner extends Functions
      * 
      * @return void
      */
-    function setgetLang() 
+    public function setgetLang()
     {
 
         if (isset($_GET['setLang'])) {
@@ -420,7 +420,7 @@ class Learner extends Functions
      * 
      * @return void
      */
-    function setgetKat() 
+    public function setgetKat()
     {
 
         if (isset($_GET['setKat'])) {
@@ -435,7 +435,7 @@ class Learner extends Functions
      * 
      * @return void
      */
-    function uebungsSelector() 
+    public function uebungsSelector()
     {
         if (!isset($_SESSION['LangDiff'])) {
             $_SESSION['LangDiff'] = 0;
@@ -473,7 +473,7 @@ class Learner extends Functions
      * 
      * @return void
      */
-    function showLang() 
+    public function showLang()
     {
 
         if (isset($_SESSION['language'])) {
@@ -604,7 +604,7 @@ class Learner extends Functions
         }
     }
 
-    function csvImport() 
+    public function csvImport()
     {
         if ($this->userHasRight(71, 0) == true) {
             if (isset($_GET['vokAdminAktivate'])) {
@@ -677,7 +677,7 @@ class Learner extends Functions
         
     }
 
-    function setPositiv() 
+    public function setPositiv()
     {
         if (isset($_GET['weiterPositiv']) AND isset($_GET['vokid'])) {
             $vokid = $_GET['vokid'];
@@ -696,7 +696,7 @@ class Learner extends Functions
         }
     }
 
-    function setNegativ() 
+    public function setNegativ()
     {
         if (isset($_GET['weiterNegativ']) AND isset($_GET['vokid'])) {
             $vokid = $_GET['vokid'];

--- a/includes/objekt/functions.class.php
+++ b/includes/objekt/functions.class.php
@@ -648,7 +648,7 @@ class Functions extends Sql
      * 
      * @return void
      */
-    function showFooter() 
+    public function showFooter()
     {
         echo "<ul>";
             echo "<li><a href='/flatnet2/informationen/impressum.php'>Impressum</a></li>";
@@ -853,7 +853,7 @@ class Functions extends Sql
      * 
      * @return string
      */
-    function checkString(string $string)
+    public function checkString(string $string)
     {
         $string = strip_tags(stripslashes($string));
         $string = str_replace(' ', '-', $string);
@@ -919,7 +919,7 @@ class Functions extends Sql
      * 
      * @return string
      */
-    function infoMessage(string $text)
+    public function infoMessage(string $text)
     {
         if (strlen($text) > 0) {
             echo "<p class='hinweis'>" . $text . "</p>";
@@ -933,7 +933,7 @@ class Functions extends Sql
      * 
      * @return string
      */
-    function erfolgMessage(string $text)
+    public function erfolgMessage(string $text)
     {
         if (strlen($text) > 0) {
             echo "<p class='erfolg'>" . $text . "</p>";
@@ -947,7 +947,7 @@ class Functions extends Sql
      * 
      * @return string
      */
-    function errorMessage(string $text)
+    public function errorMessage(string $text)
     {
         if (strlen($text) > 0) {
             echo "<p class='meldung'>" . $text . "</p>";

--- a/includes/objekt/mysql.class.php
+++ b/includes/objekt/mysql.class.php
@@ -33,7 +33,7 @@ class Sql
      * 
      * @return $db
      */
-    function connectToDB() 
+    public function connectToDB()
     {
         $this->connectToDBNewWay();
     }
@@ -43,7 +43,7 @@ class Sql
      * 
      * @return $db
      */
-    function connectToDBNewWay()
+    public function connectToDBNewWay()
     {
         try {
             $dbname = $this->getDBName();
@@ -72,7 +72,7 @@ class Sql
      * 
      * @return string
      */
-    function getDBName() 
+    public function getDBName()
     {
         $name = "62_flathacksql1";
         return $name;
@@ -85,7 +85,7 @@ class Sql
      * 
      * @return void
      */
-    function sqlDelete(string $tabelle) 
+    public function sqlDelete(string $tabelle)
     {
         if (isset($_GET['loeschen']) AND isset($_GET['loeschid']) ) {
                 
@@ -129,7 +129,7 @@ class Sql
      * 
      * @return void
      */
-    function sqlDeleteCustom(string $query) 
+    public function sqlDeleteCustom(string $query)
     {
         if (isset($_GET['loeschen']) AND isset($_GET['loeschid'])) {
             $id = $_GET['loeschid'];
@@ -169,7 +169,7 @@ class Sql
      * 
      * @return boolean
      */
-    function sqlInsertUpdateDelete(string $query) 
+    public function sqlInsertUpdateDelete(string $query)
     {
         
         $db = $this->connectToDBNewWay();
@@ -193,7 +193,7 @@ class Sql
      * 
      * @return boolean
      */
-    function sqlInsertUpdateDeleteHW(string $query) 
+    public function sqlInsertUpdateDeleteHW(string $query)
     {
         $db = $this->connectToDBNewWay();
         $affected_rows = $db->exec($query);
@@ -213,7 +213,7 @@ class Sql
      * 
      * @return boolean
      */
-    function sqlDbCheck(string $relation_name, array $structure) 
+    public function sqlDbCheck(string $relation_name, array $structure)
     {
         
         echo "<li>$relation_name</li>";
@@ -247,7 +247,7 @@ class Sql
      * 
      * @return boolean
      */
-    function logme(string $received_query) 
+    public function logme(string $received_query)
     {
         if (isset($_SESSION['username'])) {
             $username = $_SESSION['username'];
@@ -292,7 +292,7 @@ class Sql
      * 
      * @return int
      */
-    function getAmount(string $query) 
+    public function getAmount(string $query)
     {
         $db = $this->connectToDBNewWay();
         $stmt = $db->query($query);
@@ -307,7 +307,7 @@ class Sql
      * 
      * @return object
      */
-    function getObjektInfo(string $query) 
+    public function getObjektInfo(string $query)
     {
         $db = $this->connectToDBNewWay();
         $stmt = $db->query($query);
@@ -324,7 +324,7 @@ class Sql
      * 
      * @return object
      */
-    function sqlselect(string $query) 
+    public function sqlselect(string $query)
     {
         $results = $this->getObjektInfo($query);
         return $results;
@@ -337,7 +337,7 @@ class Sql
      * 
      * @return object
      */
-    function getObjectsToArray(string $query) 
+    public function getObjectsToArray(string $query)
     {
          $this->getObjektInfo($query);
     }
@@ -350,7 +350,7 @@ class Sql
      * 
      * @return boolean
      */
-    function objectExists(string $query) 
+    public function objectExists(string $query)
     {
         $row = $this->getObjektInfo($query);
 
@@ -369,7 +369,7 @@ class Sql
      * 
      * @return unknown
      */
-    function getColumns(string $table) 
+    public function getColumns(string $table)
     {
         // COLUMNS SPEICHERN;
         $select1 = "SHOW COLUMNS FROM $table";
@@ -389,7 +389,7 @@ class Sql
      * 
      * @return $columns
      */
-    function getColumnsFromQuery(string $query) 
+    public function getColumnsFromQuery(string $query)
     {
         $createTempTable = "CREATE TEMPORARY TABLE IF NOT EXISTS tempTable AS ($query);";
         $this->sqlInsertUpdateDelete($createTempTable);
@@ -410,7 +410,7 @@ class Sql
      * 
      * @return int
      */
-    function getColumnAnzahl(string $query) 
+    public function getColumnAnzahl(string $query)
     {
         $createTempTable = "
         CREATE TEMPORARY TABLE

--- a/includes/planner.class.php
+++ b/includes/planner.class.php
@@ -33,7 +33,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function plannerMainFunction() 
+    public function plannerMainFunction()
     {
         $this->doLogin();
         if (!isset($_SESSION['eventid']) OR !isset($_SESSION['eventguest'])) {
@@ -59,7 +59,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function plannerWelcome() 
+    public function plannerWelcome()
     {
         // ChangeEvent
         $this->changeEvent();
@@ -79,7 +79,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function mainEventAdministration() 
+    public function mainEventAdministration()
     {
         
         #$this->eventNavigation();
@@ -106,7 +106,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function superAdministration() 
+    public function superAdministration()
     {
         echo "<div class='newFahrt'>";
         
@@ -132,7 +132,7 @@ class Planner Extends Functions
      * 
      * @return true
      */
-    function setActive(int $eventid) 
+    public function setActive(int $eventid)
     {
         if ($this->checkEventOwner($eventid) == true) {
             $_SESSION['eventid'] = $eventid;
@@ -147,7 +147,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function listAllEvents() 
+    public function listAllEvents()
     {
         // Event aus Liste als aktiv markieren:
         if (isset($_GET['active'])) {
@@ -206,7 +206,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function deleteAdminOfEvent() 
+    public function deleteAdminOfEvent()
     {
         if (isset($_GET['deladmin'])) {
             if (isset($_GET['eventid'])) {
@@ -229,7 +229,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function deleteCodeOfEvent()
+    public function deleteCodeOfEvent()
     {
         if (isset($_GET['delInvCode'])) {
             if (isset($_GET['eventid'])) {
@@ -274,7 +274,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function listAllEventAdministrators() 
+    public function listAllEventAdministrators()
     {
         if ($this->userHasRight(79, 0) == true) {
             echo "<div class='separateDivBox'>";
@@ -305,7 +305,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function createNewAdminOfEvent() 
+    public function createNewAdminOfEvent()
     {
         
         echo "<div class=''>";
@@ -371,7 +371,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function createNewEvent() 
+    public function createNewEvent()
     {
         // SPEICHERUNG
         if (isset($_POST['eventname'])) {
@@ -416,7 +416,7 @@ class Planner Extends Functions
      * 
      * @return string
      */
-    function getEventname(int $eventid) 
+    public function getEventname(int $eventid)
     {
         $eventname = $this->sqlselect("SELECT id, eventname FROM eventlist WHERE id=$eventid LIMIT 1");
 
@@ -428,7 +428,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function newheader() 
+    public function newheader()
     {
         echo '<meta http-equiv="content-type" content="text/html; charset=utf-8" />';
         echo '<link rel="apple-touch-icon" sizes="57x57" href="/apple-icon-57x57.png">';
@@ -491,7 +491,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function showFooter() 
+    public function showFooter()
     {
         // AUSGABE
         echo "<div class='newFahrt'><div class='footer'>";
@@ -507,7 +507,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function eventNavigation() 
+    public function eventNavigation()
     {
         echo "<ul class='finanzNAV'>";
         if (isset($_SESSION['username'])) {
@@ -527,7 +527,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function eventAdministration() 
+    public function eventAdministration()
     {   
         echo "<li><a id='login' href='index.php'>Login</a></li>";
         echo "<li><a id='evadmin' href='administration.php'>Administration</a></li>";
@@ -543,7 +543,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function addGuests() 
+    public function addGuests()
     {
         // SPEICHERUNG
         if (isset($_POST['guestname']) AND isset($_POST['guestcount']) AND isset($_POST['fullname'])) {
@@ -591,7 +591,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function addInviteCode(int $eventid) 
+    public function addInviteCode(int $eventid)
     {
         
         echo "<div class=''>";
@@ -633,7 +633,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function getGuestName(int $guestid) 
+    public function getGuestName(int $guestid)
     {
         $guestname = $this->sqlselect("SELECT id,guestname,fullname FROM eventguests WHERE id=$guestid LIMIT 1");
         if (isset($guestname[0]->fullname)) {
@@ -655,7 +655,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function showInviteCodes(int $eventid)
+    public function showInviteCodes(int $eventid)
     {
         echo "<div class='separateDivBox'>";
         
@@ -691,7 +691,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function showManageCountdowns(int $eventid) 
+    public function showManageCountdowns(int $eventid)
     {
         echo "<div class='separateDivBox'>";
         echo "<h3><a name='countdowns'>Countdowns</a></h3>";
@@ -719,7 +719,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function addCountdown(int $eventid) 
+    public function addCountdown(int $eventid)
     {
         
         echo "<div class=''>";
@@ -757,7 +757,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function deleteCountdown()
+    public function deleteCountdown()
     {
         if (isset($_GET['delCD'])) {
             if (isset($_GET['eventid'])) {
@@ -780,7 +780,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function doLogin() 
+    public function doLogin()
     {
         if (isset($_POST['submit'])) {
             $username = strip_tags($_POST['username']);
@@ -819,7 +819,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function eventSelector() 
+    public function eventSelector()
     {
         echo "<div class='eventlogin'>";
         
@@ -860,7 +860,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function updateCodesUsed(int $codeid, int $guestid) 
+    public function updateCodesUsed(int $codeid, int $guestid)
     {
         // Checke ob Eintrag bereits existiert
         $alreadyused = $this->sqlselect("SELECT * FROM eventcodeusage WHERE userid=$guestid");
@@ -879,7 +879,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function changeEvent() 
+    public function changeEvent()
     {
         if (isset($_GET['eventchange'])) {
             unset($_SESSION['eventid']);
@@ -892,7 +892,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function changeGuest() 
+    public function changeGuest()
     {
         if (isset($_GET['guestlogout'])) {
             unset($_SESSION['eventguest']);
@@ -904,7 +904,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function setGuest() 
+    public function setGuest()
     {
         if (isset($_GET['setGuest'])) {
             if (is_numeric($_GET['setGuest']) == true) {
@@ -919,7 +919,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function showEvent() 
+    public function showEvent()
     {
         if (isset($_SESSION['eventid']) AND isset($_SESSION['eventguest'])) {
             // event und gast informationen
@@ -945,7 +945,7 @@ class Planner Extends Functions
         }
     }
 
-    function showWelcomeMessage($eventid)
+    public function showWelcomeMessage($eventid)
     {
         echo "<div class=''>";
         $welcomemsg = $this->sqlselect("SELECT * FROM eventlist WHERE id=$eventid LIMIT 1");
@@ -977,7 +977,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function askUserForZusage(int $eventid) 
+    public function askUserForZusage(int $eventid)
     {
         if (isset($_SESSION['eventguest'])) {
             echo "<div class=''>";
@@ -1011,7 +1011,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function askUserForCount(int $eventid) 
+    public function askUserForCount(int $eventid)
     {
         // CHECK IF USER HASNT ZUGESAGT YET
         // echo "<div class='newFahrt'>";
@@ -1027,7 +1027,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function showBlogMessages(int $eventid) 
+    public function showBlogMessages(int $eventid)
     {
         // CHECK IF USER HASNT ZUGESAGT YET
         echo "<div class=''>";
@@ -1069,7 +1069,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function createNewBlogMessage(int $eventid) 
+    public function createNewBlogMessage(int $eventid)
     {
         // SPEICHERUNG
         if (isset($_POST['blogtext'])) {
@@ -1125,7 +1125,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function editBlogMessage(int $eventid) 
+    public function editBlogMessage(int $eventid)
     {
         // SPEICHERUNG
         if (isset($_POST['editblogentry']) AND isset($_POST['editblogid'])) {
@@ -1186,7 +1186,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function delBlogMessage(int $eventid)
+    public function delBlogMessage(int $eventid)
     {
         if (isset($_GET['delBlog'])) {
             if (is_numeric($_GET['delBlog']) == true) {
@@ -1213,7 +1213,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function showCountdowns(int $eventid) 
+    public function showCountdowns(int $eventid)
     {
         // CHECK IF USER HASNT ZUGESAGT YET
         echo "<div class='separateDivBox'>";
@@ -1235,7 +1235,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function showSmallGuestList() 
+    public function showSmallGuestList()
     {
         $eventid = $_SESSION['eventid'];
         $memberlist = $this->sqlselect("SELECT * FROM eventguests WHERE eventid=$eventid ORDER BY guestname");
@@ -1272,7 +1272,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function checkEventOwner(int $eventid) 
+    public function checkEventOwner(int $eventid)
     {
         $administrator = $this->sqlselect("SELECT * FROM eventadministrators WHERE eventid=$eventid");
         $found = 0;
@@ -1306,7 +1306,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function deleteEventGuest()
+    public function deleteEventGuest()
     {
         if (isset($_GET['delUser']) AND isset($_GET['eventid'])) {
             $userid = $_GET['delUser'];
@@ -1333,7 +1333,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function zusageGuest()
+    public function zusageGuest()
     {
         if (isset($_GET['zusageUser']) AND isset($_SESSION['eventid'])) {
             if (is_numeric($_GET['zusageUser']) AND is_numeric($_SESSION['eventid'])) {
@@ -1364,7 +1364,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function absageGuest()
+    public function absageGuest()
     {
         if (isset($_GET['absageUser']) AND isset($_SESSION['eventid'])) {
             if (is_numeric($_GET['absageUser']) AND is_numeric($_SESSION['eventid'])) {
@@ -1394,7 +1394,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function counterAction() 
+    public function counterAction()
     {
         // Runter zählen
         if (isset($_GET['CounterDOWN']) AND isset($_GET['eventid']) AND isset($_GET['wert'])) {
@@ -1444,7 +1444,7 @@ class Planner Extends Functions
      * 
      * @return void
      */
-    function showEventMembers(int $eventid) 
+    public function showEventMembers(int $eventid)
     {
         $memberlist = $this->sqlselect("SELECT * FROM eventguests WHERE eventid=$eventid ORDER BY zusage,guestname");
         if ($this->checkEventOwner($eventid) == true) { 

--- a/includes/uebersicht.class.php
+++ b/includes/uebersicht.class.php
@@ -282,7 +282,7 @@ class Uebersicht extends Functions
      * 
      * @return void
      */
-    function newUebersicht()
+    public function newUebersicht()
     {
         $kacheln = $this->sqlselect("SELECT * FROM uebersicht_kacheln WHERE active=1 ORDER BY sortierung, name, id");
         $kachelnInactive = $this->sqlselect("SELECT * FROM uebersicht_kacheln WHERE active=0 ORDER BY sortierung, name, id");


### PR DESCRIPTION
## Summary
- add explicit `public` modifiers to PHP methods missing visibility
- keep indentation consistent

## Testing
- `php -l includes/finanzen.class.php`
- `php -l includes/learner.class.php`
- `php -l includes/planner.class.php`
- `php -l includes/uebersicht.class.php`
- `php -l includes/objekt/functions.class.php`
- `php -l includes/objekt/mysql.class.php`


------
https://chatgpt.com/codex/tasks/task_e_6888a328cf3c8323bdfe21f8264836a7