### PR TITLE
Fix PHP variable interpolation warnings

### DIFF
--- a/includes/finanzen.class.php
+++ b/includes/finanzen.class.php
@@ -1887,7 +1887,7 @@ class FinanzenNEW extends functions
                                         for ($x = 1; $x <= $number; $x++) {
                                             $newdate = new DateTime($datum);
                                             $newdate->modify("+$x month");
-                                            echo "<p class='dezentInfo'>${x}: Buchung f&uuml;r Monat " . $newdate->format("Y-m-d") . "</p>";
+                                            echo "<p class='dezentInfo'>{$x}: Buchung f&uuml;r Monat " . $newdate->format("Y-m-d") . "</p>";
 
                                             $this->createUeberweisung($besitzer, $von, $nach, $text, $betrag, $newdate->format("Y-m-d"), $link);
 

--- a/includes/objekt/mysql.class.php
+++ b/includes/objekt/mysql.class.php
@@ -456,7 +456,7 @@ class Sql
         , string $defaultPfad
         , string $besitzerFeld
     ) {
-        if (isset($_POST["${uniqueName}Submit"])) {
+        if (isset($_POST["{$uniqueName}Submit"])) {
             $currentObject = $_POST['currentObject'];
             $columns = $this->getColumns($tableName);
 
@@ -564,7 +564,7 @@ class Sql
             }
         }
         echo "<tbody>"; 
-        echo "<td><button type=submit name=${uniqueName}Submit />Speichern</button></td>"; 
+        echo "<td><button type=submit name={$uniqueName}Submit>Speichern</button></td>";
         echo "<td><a href=\"$defaultPfad\" class='highlightedLink'>Zurück</a></td>";
         echo "</tbody>";
         echo "</form></table>";


### PR DESCRIPTION
## Summary
- update deprecated variable interpolation syntax in mysql and finanzen modules

## Testing
- `find includes/objekt/mysql.class.php includes/finanzen.class.php -print0 | xargs -0 php -l`
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_6888a725de588323972a314dbbd9ca77